### PR TITLE
User now must select a listening period

### DIFF
--- a/src/components/liveReports/LiveReportForm.js
+++ b/src/components/liveReports/LiveReportForm.js
@@ -29,7 +29,7 @@ export const LiveReportForm = () => {
     useEffect(() => {
         loadData()
         getCurrentUser()
-        return(() => {
+        return (() => {
             setLiveReport({})
         })
     }, [])
@@ -44,11 +44,15 @@ export const LiveReportForm = () => {
 
     const handleSubmit = e => {
         e.preventDefault()
-        const typeString = 'artists'
-        const period = periods.find(p => p.id === apiParams.periodId)
-        const periodString = period.query
-        const service = services.find(s => s.id === currentUser.serviceId)
-        getLiveReport(typeString, periodString, apiParams.limit, currentUser, period, service)
+        if (apiParams.periodId > 0) {
+            const typeString = 'artists'
+            const period = periods.find(p => p.id === apiParams.periodId)
+            const periodString = period.query
+            const service = services.find(s => s.id === currentUser.serviceId)
+            getLiveReport(typeString, periodString, apiParams.limit, currentUser, period, service)
+        } else {
+            window.alert("Please select a listening period")
+        }
     }
 
 
@@ -76,8 +80,8 @@ export const LiveReportForm = () => {
             </form>
             {Object.keys(liveReport).length > 0 &&
                 <ReportTable report={liveReport}
-                    
-                    />
+
+                />
             }
         </>
     )


### PR DESCRIPTION
# Prevent Unselected Period
## Description

Previously if a user did not select a period, the page would break. Now, instead, an alert pops up.

Closes #

### Type
- [x] Bug squish
- [ ] New Feature
- [ ] Documentation