### PR TITLE
Uniform Material UI Elements in all pages (save registration)

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -195,6 +195,26 @@
       "paid": false,
       "suggestionId": 3,
       "id": 19
+    },
+    {
+      "userId": 1,
+      "timestamp": 1617385512376,
+      "trackCount": 529,
+      "periodId": 2,
+      "name": "Top 15 artists for the last month, 3/2/2021",
+      "paid": true,
+      "suggestionId": 1,
+      "id": 20
+    },
+    {
+      "userId": 1,
+      "timestamp": 1617385586294,
+      "trackCount": 29,
+      "periodId": 1,
+      "name": "Top 20 artists for the last week, 4/2/2021",
+      "paid": false,
+      "suggestionId": 1,
+      "id": 21
     }
   ],
   "artists": [
@@ -341,6 +361,34 @@
     {
       "name": "Sufjan Stevens",
       "id": 36
+    },
+    {
+      "name": "Can",
+      "id": 37
+    },
+    {
+      "name": "Fugazi",
+      "id": 38
+    },
+    {
+      "name": "George Harrison",
+      "id": 39
+    },
+    {
+      "name": "Arcade Fire",
+      "id": 40
+    },
+    {
+      "name": "Lianne La Havas",
+      "id": 41
+    },
+    {
+      "name": "Modest Mouse",
+      "id": 42
+    },
+    {
+      "name": "Regina Spektor",
+      "id": 43
     }
   ],
   "planArtists": [
@@ -1027,6 +1075,216 @@
       "planId": 19,
       "trackCount": 34,
       "id": 186
+    },
+    {
+      "artistId": 2,
+      "planId": 20,
+      "trackCount": 69,
+      "id": 187
+    },
+    {
+      "artistId": 5,
+      "planId": 20,
+      "trackCount": 34,
+      "id": 188
+    },
+    {
+      "artistId": 14,
+      "planId": 20,
+      "trackCount": 43,
+      "id": 189
+    },
+    {
+      "artistId": 8,
+      "planId": 20,
+      "trackCount": 37,
+      "id": 190
+    },
+    {
+      "artistId": 10,
+      "planId": 20,
+      "trackCount": 35,
+      "id": 191
+    },
+    {
+      "artistId": 1,
+      "planId": 20,
+      "trackCount": 34,
+      "id": 192
+    },
+    {
+      "artistId": 12,
+      "planId": 20,
+      "trackCount": 32,
+      "id": 193
+    },
+    {
+      "artistId": 4,
+      "planId": 20,
+      "trackCount": 31,
+      "id": 194
+    },
+    {
+      "artistId": 36,
+      "planId": 20,
+      "trackCount": 29,
+      "id": 195
+    },
+    {
+      "artistId": 3,
+      "planId": 20,
+      "trackCount": 28,
+      "id": 196
+    },
+    {
+      "artistId": 6,
+      "planId": 20,
+      "trackCount": 42,
+      "id": 197
+    },
+    {
+      "artistId": 15,
+      "planId": 20,
+      "trackCount": 30,
+      "id": 198
+    },
+    {
+      "artistId": 11,
+      "planId": 20,
+      "trackCount": 30,
+      "id": 199
+    },
+    {
+      "artistId": 13,
+      "planId": 20,
+      "trackCount": 27,
+      "id": 200
+    },
+    {
+      "artistId": 7,
+      "planId": 20,
+      "trackCount": 28,
+      "id": 201
+    },
+    {
+      "artistId": 20,
+      "planId": 21,
+      "trackCount": 4,
+      "id": 202
+    },
+    {
+      "artistId": 8,
+      "planId": 21,
+      "trackCount": 2,
+      "id": 203
+    },
+    {
+      "artistId": 7,
+      "planId": 21,
+      "trackCount": 3,
+      "id": 204
+    },
+    {
+      "artistId": 6,
+      "planId": 21,
+      "trackCount": 3,
+      "id": 205
+    },
+    {
+      "artistId": 19,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 206
+    },
+    {
+      "artistId": 35,
+      "planId": 21,
+      "trackCount": 2,
+      "id": 207
+    },
+    {
+      "artistId": 3,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 208
+    },
+    {
+      "artistId": 10,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 209
+    },
+    {
+      "artistId": 11,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 210
+    },
+    {
+      "artistId": 9,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 211
+    },
+    {
+      "artistId": 23,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 212
+    },
+    {
+      "artistId": 5,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 213
+    },
+    {
+      "artistId": 36,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 214
+    },
+    {
+      "artistId": 39,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 215
+    },
+    {
+      "artistId": 37,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 216
+    },
+    {
+      "artistId": 40,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 217
+    },
+    {
+      "artistId": 42,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 218
+    },
+    {
+      "artistId": 41,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 219
+    },
+    {
+      "artistId": 38,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 220
+    },
+    {
+      "artistId": 43,
+      "planId": 21,
+      "trackCount": 1,
+      "id": 221
     }
   ],
   "users": [

--- a/api/database.json
+++ b/api/database.json
@@ -112,7 +112,7 @@
       "trackCount": 79,
       "periodId": 1,
       "name": "Top 5 artists for the last week, 2/22/2021",
-      "paid": false,
+      "paid": true,
       "suggestionId": 3,
       "id": 10
     },
@@ -143,7 +143,7 @@
       "periodId": 1,
       "name": "Top 5 artists for the last week, 2/23/2021",
       "paid": true,
-      "suggestionId": 3,
+      "suggestionId": 2,
       "id": 13
     },
     {
@@ -172,7 +172,7 @@
       "trackCount": 405,
       "periodId": 2,
       "name": "Top 20 artists for the last month, 2/26/2021",
-      "paid": true,
+      "paid": false,
       "suggestionId": 4,
       "id": 16
     },
@@ -183,8 +183,18 @@
       "periodId": 2,
       "name": "Top 20 artists for the last month, 2/26/2021",
       "paid": false,
-      "suggestionId": 2,
+      "suggestionId": 1,
       "id": 18
+    },
+    {
+      "userId": 1,
+      "timestamp": 1617383741539,
+      "trackCount": 326,
+      "periodId": 2,
+      "name": "Top 8 artists for the last month, 3/2/2021",
+      "paid": false,
+      "suggestionId": 3,
+      "id": 19
     }
   ],
   "artists": [
@@ -969,6 +979,54 @@
       "planId": 18,
       "trackCount": 29,
       "id": 178
+    },
+    {
+      "artistId": 2,
+      "planId": 19,
+      "trackCount": 69,
+      "id": 179
+    },
+    {
+      "artistId": 6,
+      "planId": 19,
+      "trackCount": 42,
+      "id": 180
+    },
+    {
+      "artistId": 14,
+      "planId": 19,
+      "trackCount": 43,
+      "id": 181
+    },
+    {
+      "artistId": 8,
+      "planId": 19,
+      "trackCount": 37,
+      "id": 182
+    },
+    {
+      "artistId": 10,
+      "planId": 19,
+      "trackCount": 35,
+      "id": 183
+    },
+    {
+      "artistId": 5,
+      "planId": 19,
+      "trackCount": 34,
+      "id": 184
+    },
+    {
+      "artistId": 12,
+      "planId": 19,
+      "trackCount": 32,
+      "id": 185
+    },
+    {
+      "artistId": 1,
+      "planId": 19,
+      "trackCount": 34,
+      "id": 186
     }
   ],
   "users": [

--- a/api/database.json
+++ b/api/database.json
@@ -172,7 +172,7 @@
       "trackCount": 405,
       "periodId": 2,
       "name": "Top 20 artists for the last month, 2/26/2021",
-      "paid": false,
+      "paid": true,
       "suggestionId": 4,
       "id": 16
     },
@@ -182,7 +182,7 @@
       "trackCount": 654,
       "periodId": 2,
       "name": "Top 20 artists for the last month, 2/26/2021",
-      "paid": true,
+      "paid": false,
       "suggestionId": 2,
       "id": 18
     }
@@ -979,7 +979,7 @@
       "lastFmAccount": "SubtleCo",
       "password": "qwerty",
       "serviceId": 3,
-      "suggestionId": 2,
+      "suggestionId": 1,
       "id": 1
     },
     {

--- a/src/components/NavBar/NavBar.css
+++ b/src/components/NavBar/NavBar.css
@@ -1,24 +1,3 @@
-/* .nav{
-    display: flex;
-} */
-
-/* .nav__right{
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    background-color: aquamarine;
-} */
-
-/* h1{
-    align-self: center;
-} */
-
-/* #navbar{
-    display: flex;
-    justify-content: space-evenly;
-    padding-bottom: 10px;
-} */
-
 .navItem {
     text-decoration: none;
 }

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -45,13 +45,13 @@ export const NavBar = ({ theme }) => {
                         <LibraryMusicIcon />
                     </IconButton>
                     <Typography variant="h5" color="inherit" className={classes.navItem} to="/" component={Link}>
-                        TipHat
+                        TIPHAT
                     </Typography>
                     <Typography variant="h5" color="inherit" className={classes.navItem} to="/reports/create" component={Link}>
-                        Generate A Report
+                        GENERATE A REPORT
                     </Typography>
                     <Typography variant="h5" color="inherit" className={classes.navItem} to="/reports" component={Link}>
-                        Saved Reports
+                        SAVED REPORTS
                     </Typography>
                     {/* <Typography variant="h5" color="inherit" className={classes.navItem} to="/user/edit" component={Link}>
                         Profile

--- a/src/components/liveReports/LiveReportForm.js
+++ b/src/components/liveReports/LiveReportForm.js
@@ -7,7 +7,7 @@ import { services, getServices } from '../services/ServiceProvider'
 import { periods, getPeriods } from '../periods/PeriodProvider'
 import './LiveReportForm.css'
 import { ReportTable } from './ReportTable'
-import { makeStyles, Typography, Button } from '@material-ui/core'
+import { makeStyles, Typography, Button, Select, MenuItem, Input } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
     tableButton: {
@@ -56,8 +56,8 @@ export const LiveReportForm = ({ theme }) => {
     const handleInputChange = e => {
         const newParams = { ...apiParams }
         let selectedValue = e.target.value
-        if (e.target.id.includes("Id")) selectedValue = parseInt(selectedValue)
-        newParams[e.target.id] = selectedValue
+        if (e.target.name.includes("Id")) selectedValue = parseInt(selectedValue)
+        newParams[e.target.name] = selectedValue
         setApiParams(newParams)
     }
 
@@ -86,16 +86,16 @@ export const LiveReportForm = ({ theme }) => {
                 <div className="api__form__selects">
                     <p className="api__form__p">I'd like to see my top</p>
                     <fieldset>
-                        <input id="limit" type='number' min="5" max="50" value={apiParams.limit} onChange={handleInputChange}></input>
+                        <Input name="limit" id="limit" type='number' min="5" max="50" value={apiParams.limit} onChange={handleInputChange}></Input>
                     </fieldset>
                     <p className="api__form__p">artists for</p>
                     <fieldset>
-                        <select id="periodId" onChange={handleInputChange}>
-                            <option value="0">Select a period</option>
+                        <Select id="periodId" name="periodId" defaultValue={0} onChange={handleInputChange}>
+                            <MenuItem value="0">Select a period</MenuItem>
                             {
-                                periods.map(period => <option key={"period " + period.id} value={period.id} onChange={handleInputChange}>{period.name}</option>)
+                                periods.map(period => <MenuItem key={"period " + period.id} value={period.id}>{period.name}</MenuItem>)
                             }
-                        </select>
+                        </Select>
                     </fieldset>
                     <Button className={classes.tableButton} onClick={handleSubmit} id="apiSubmit">Please</Button>
                 </div>

--- a/src/components/liveReports/ReportTable.js
+++ b/src/components/liveReports/ReportTable.js
@@ -83,6 +83,7 @@ export const ReportTable = (props) => {
     const [reportTable, setReportTable] = useState([])
     // This helps ensure our API data is loaded before performing operations that require it
     const [isLoading, setIsLoading] = useState(true)
+    const [suggestionSelect, setSuggestionSelect] = useState("")
 
     const history = useHistory()
 
@@ -119,6 +120,15 @@ export const ReportTable = (props) => {
     useEffect(() => {
         setSuggestion(suggestions.find(s => s.id === report.user.suggestionId))
     }, [isLoading])
+
+    useEffect(() => {
+        setSuggestionSelect(suggestion?.id &&
+                <Select className={classes.valueSelect} id="suggestionSelect" value={suggestion.id} onChange={handleLiveSuggestionChange}>
+                    {
+                        suggestions.map(s => <MenuItem key={"suggestion " + s.id} value={s.id}>{s.name}</MenuItem>)
+                    }
+                </Select>)
+    }, [suggestion])
 
     // This watches the suggestion select to change the state variable of suggestion if the user wants to recalculate the report with a different track value
     const handleLiveSuggestionChange = e => {
@@ -179,11 +189,6 @@ export const ReportTable = (props) => {
 
     const totalRevenue = reportTable.map(row => parseFloat(row.playcount * report.service.amount)).reduce((a, b) => a + b, 0).toFixed(2)
     const totalPotential = reportTable.map(row => parseFloat(row.playcount * suggestion?.amount)).reduce((a, b) => a + b, 0).toFixed(2)
-    const valueSelect = <Select className={classes.valueSelect} id="suggestionSelect" defaultValue={report.user.suggestionId} value={suggestion?.id} onChange={handleLiveSuggestionChange}>
-        {
-            suggestions.map(s => <MenuItem key={"suggestion " + s.id} value={s.id}>{s.name}</MenuItem>)
-        }
-    </Select>
 
     return (
         <>
@@ -196,7 +201,7 @@ export const ReportTable = (props) => {
                             <TableCell className={classes.head} align="center">Play Share</TableCell>
                             <TableCell className={classes.head} align="center">Track Count</TableCell>
                             <TableCell className={classes.head} align="center">Estimated {report.service.name} Revenue</TableCell>
-                            <TableCell className={classes.head} align="center">Potential Revenue (as {valueSelect})</TableCell>
+                            <TableCell className={classes.head} align="center">Potential Revenue (as {suggestionSelect})</TableCell>
                             <TableCell className={classes.head} align="center">Suggestion</TableCell>
                         </TableRow>
                     </TableHead>

--- a/src/components/liveReports/ReportTable.js
+++ b/src/components/liveReports/ReportTable.js
@@ -149,7 +149,7 @@ export const ReportTable = (props) => {
         newPlan.trackCount = totalCount
         newPlan.periodId = reportPeriod.id
         // As "reportTable" is an array of items derived from the API, and each line represents and artist, .length will provide a total count of artists
-        newPlan.name = `Top ${reportTable.length} artists for ${reportPeriod.name}, ${new Date(newPlan.timestamp).getMonth()}/${new Date(newPlan.timestamp).getDate()}/${new Date(newPlan.timestamp).getFullYear()}`
+        newPlan.name = `Top ${reportTable.length} artists for ${reportPeriod.name}, ${new Date(newPlan.timestamp).getMonth() + 1}/${new Date(newPlan.timestamp).getDate()}/${new Date(newPlan.timestamp).getFullYear()}`
         // There are two submit buttons - one with "paid" in the id and one without. These buttons will determine if a plan is paid or not.
         newPlan.paid = e.currentTarget.id.includes("paid")
         newPlan.suggestionId = suggestion.id

--- a/src/components/reports/ReportCard.js
+++ b/src/components/reports/ReportCard.js
@@ -1,14 +1,43 @@
 // This module represents a saved plan to the user with its title, whether or not the plan is paid, and buttons to affect the plan.
 // Called directly by ReportList
 
+import { Button, makeStyles, Typography } from '@material-ui/core'
 import React, { useContext } from 'react'
 import { useHistory } from 'react-router'
 import { PlanContext } from '../plans/PlanProvider'
 
-export const ReportCard = ({ report }) => {
+const useStyles = makeStyles(theme => ({
+    delete: {
+        backgroundColor: theme.palette.secondary.main,
+        color: theme.palette.common.white,
+        fontWeight: 900,
+        margin: theme.spacing(1)
+    },
+    view: {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.common.white,
+        fontWeight: 900,
+        margin: theme.spacing(1)
+    },
+    pay: {
+        backgroundColor: theme.palette.success.light,
+        color: theme.palette.common.white,
+        fontWeight: 900,
+        margin: theme.spacing(1)
+    },
+    unpay: {
+        backgroundColor: theme.palette.primary.light,
+        color: theme.palette.common.white,
+        fontWeight: 900,
+        margin: theme.spacing(1)
+    }
+}))
+
+export const ReportCard = ({ report, theme }) => {
     const { deletePlan, editPlan } = useContext(PlanContext)
     const history = useHistory()
     const paid = report.paid
+    const classes = useStyles(theme)
 
     const handleDelete = e => {
         deletePlan(report.id)
@@ -32,21 +61,21 @@ export const ReportCard = ({ report }) => {
 
     let buttons = (
         <div className="reportCard__buttons">
-            <button className="button btn-go" onClick={handleMarkPaid}>Mark As Paid</button>
-            <button className="button btn-edit" onClick={handleEdit}>View/Edit</button>
-            <button className="button btn-delete" onClick={handleDelete}>Delete</button>
+            <Button className={classes.pay} variant="contained" onClick={handleMarkPaid}>Mark As Paid</Button>
+            <Button className={classes.view} variant="contained" onClick={handleEdit}>View/Edit</Button>
+            <Button className={classes.delete} variant="contained" onClick={handleDelete}>Delete</Button>
         </div>
     )
     if (paid) buttons = (
         <div className="reportCard__buttons">
-            <button className="button btn-edit" onClick={handleMarkUnpaid}>Mark As Unpaid</button>
-            <button className="button btn-view" onClick={handleView}>View</button>
+            <Button className={classes.unpay} variant="contained" onClick={handleMarkUnpaid}>Mark As Unpaid</Button>
+            <Button className={classes.view} variant="contained" onClick={handleView}>View</Button>
         </div>
     )
 
     return (
         <article className="savedReport">
-            <h4>{report.name}</h4>
+            <Typography component="h2" variant="h5" >{report.name}</Typography>
             {buttons}
         </article>
     )

--- a/src/components/reports/ReportList.css
+++ b/src/components/reports/ReportList.css
@@ -1,16 +1,5 @@
-#savedReports__unpaid {
-    background-color: cornsilk;
-}
-#savedReports__paid {
-    background-color: rgb(119, 221, 119);
-}
-
 .savedReport{
     display: flex;
     align-items: center;
     justify-content: space-between;
-}
-
-.savedReports__section--title {
-    text-align: center;
 }

--- a/src/components/reports/ReportList.js
+++ b/src/components/reports/ReportList.js
@@ -1,16 +1,32 @@
 // This module gets all plans from the DB, filters them to the current user, sorts them in order of timestamp, and divides them into paid / unpaid plans.
 // Each plan is then afforded a "ReportCard"
 
+import { makeStyles, Typography } from '@material-ui/core'
 import React, { useContext, useEffect, useState } from 'react'
 import { currentUser, getCurrentUser } from '../auth/UserProvider'
 import { PlanContext } from '../plans/PlanProvider'
 import { ReportCard } from './ReportCard'
 import './ReportList.css'
 
+const useStyles = makeStyles(theme => ({
+    section: {
+        margin: theme.spacing(4),
+        padding: theme.spacing(2),
+        border: "1px solid black",
+        borderRadius: 5,
+        backgroundColor: theme.palette.primary.contrastText
+    },
+    title: {
+        textAlign: "center",
+        marginBottom: theme.spacing(4)
+    }
+}))
+
 export const ReportList = props => {
     const { plans, getPlans } = useContext(PlanContext)
     const [displayPaidPlans, setDisplayPaidPlans] = useState([])
     const [displayUnpaidPlans, setDisplayUnpaidPlans] = useState([])
+    const classes = useStyles(props.theme)
 
     useEffect(() => {
         getPlans()
@@ -29,17 +45,17 @@ export const ReportList = props => {
     return (
         
         <section className="savedReports--container main__container">
-            <h2>Your Saved Reports</h2>
+            <Typography component="h2" variant="h2" align='center'>Your Saved Reports</Typography>
 
-            <section id="savedReports__unpaid">
-                <h3 className="savedReports__section--title">Unpaid Reports</h3>
+            <section className={classes.section}>
+                <Typography variant="h4" className={classes.title}>Unpaid Reports</Typography>
                 {
                     displayUnpaidPlans.map(dP => <ReportCard key={dP.id} report={dP} />)
                 }
             </section>
 
-            <section id="savedReports__paid">
-                <h3 className="savedReports__section--title">Paid Reports</h3>
+            <section className={classes.section}>
+                <Typography variant="h4" className={classes.title}>Paid Reports</Typography>
                 {
                     displayPaidPlans.map(dP => <ReportCard key={dP.id} report={dP} />)
                 }

--- a/src/components/reports/ViewReport.js
+++ b/src/components/reports/ViewReport.js
@@ -20,7 +20,7 @@ import TableContainer from '@material-ui/core/TableContainer'
 import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import Paper from '@material-ui/core/Paper'
-import { Button, LinearProgress } from '@material-ui/core'
+import { Button, LinearProgress, Select, MenuItem } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
     tableContainer: {
@@ -59,6 +59,13 @@ const useStyles = makeStyles((theme) => ({
         '&:hover': {
             backgroundColor: theme.palette.primary.dark
         }
+    },
+    valueSelect: {
+        backgroundColor: theme.palette.common.white,
+        margin: "0px 5px",
+        paddingLeft: 5,
+        borderRadius: 5,
+        width: "190px"
     }
 }))
 
@@ -67,6 +74,7 @@ export const ViewReport = () => {
     const [thisPlan, setThisPlan] = useState({})
     const [displayPlan, setDisplayPlan] = useState({})
     const [isLoading, setIsLoading] = useState(true)
+    const [suggestionSelect, setSuggestionSelect] = useState("")
 
     const { planId } = useParams()
     const history = useHistory()
@@ -128,6 +136,19 @@ export const ViewReport = () => {
 
     }, [thisPlan, isLoading])
 
+    useEffect(() => {
+        if (displayPlan.paid === true) {
+            setSuggestionSelect(displayPlan.suggestion?.id && displayPlan.suggestion.name)
+        } else {
+            setSuggestionSelect(displayPlan.suggestion?.id &&
+                <Select className={classes.valueSelect} id="suggestionSelect" value={displayPlan.suggestion.id} onChange={handleLiveSuggestionChange}>
+                    {
+                        suggestions.map(s => <MenuItem key={"suggestion " + s.id} value={s.id}>{s.name}</MenuItem>)
+                    }
+                </Select>)
+        }
+    }, [displayPlan])
+
     // if plan is not paid, allows user to edit suggestion / track value
     const handleLiveSuggestionChange = e => {
         const newPlan = { ...displayPlan }
@@ -150,16 +171,7 @@ export const ViewReport = () => {
             <h2>Your top {displayPlan?.artistCount} artists for {displayPlan.period?.name}</h2>
 
             {/* if this plan is unpaid, allow user to edit suggestion / track value. */}
-            {displayPlan?.paid ? <p>This Plan is Paid!</p> :
-                <>
-                    <label htmlFor="suggestionSelect">Change the payout calculation to </label>
-                    <select id="suggestionSelect" value={displayPlan.suggestion?.id} onChange={handleLiveSuggestionChange} className="report__trackValueSelect">
-                        {
-                            suggestions.map(s => <option key={"suggestion " + s.id} value={s.id}>{s.name}</option>)
-                        }
-                    </select>
-                </>
-            }
+            {displayPlan?.paid ? <p>This Plan is Paid!</p> : ""}
 
             <TableContainer className={classes.tableContainer} component={Paper}>
                 <Table className={classes.table} aria-label="simple table">
@@ -169,7 +181,7 @@ export const ViewReport = () => {
                             <TableCell className={classes.head} align="center">Play Share</TableCell>
                             <TableCell className={classes.head} align="center">Track Count</TableCell>
                             <TableCell className={classes.head} align="center">Estimated {displayPlan.service?.name} Revenue</TableCell>
-                            <TableCell className={classes.head} align="center">Potential Revenue (as {displayPlan.suggestion?.name})</TableCell>
+                            <TableCell className={classes.head} align="center">Potential Revenue (as {suggestionSelect})</TableCell>
                             <TableCell className={classes.head} align="center">Suggestion</TableCell>
                         </TableRow>
                     </TableHead>
@@ -201,38 +213,6 @@ export const ViewReport = () => {
                     </TableBody>
                 </Table>
             </TableContainer >
-            {/* <table className="reportTable">
-
-                <thead>
-                    <tr>
-                        <th>Artist</th>
-                        <th>Track Count</th>
-                        <th>% of report</th>
-                        <th>Estimated {displayPlan.service?.name} Payout</th>
-                        <th>Estimated Potential Payout (as {displayPlan.suggestion?.name})</th>
-                        <th>Suggested Donation</th>
-                    </tr>
-                </thead>
-
-                <tbody className="reportTable--body">
-                    {
-                        displayPlan.reportTable.map((line, i) => {
-                            const payout = (line.playcount * displayPlan.service?.amount).toFixed(2)
-                            const potential = (line.playcount * displayPlan.suggestion.amount).toFixed(2)
-                            return (
-                                <tr key={i}>
-                                    <td>{line.name}</td>
-                                    <td>{line.playcount}</td>
-                                    <td>{(line.playcount / displayPlan.trackCount * 100).toFixed(0)}%</td>
-                                    <td>${payout}</td>
-                                    <td>${potential}</td>
-                                    <td>${(potential - payout).toFixed(2)}</td>
-                                </tr>
-                            )
-                        })
-                    }
-                </tbody>
-            </table> */}
 
             {/* if this plan is unpaid, allow the user to save the edited version to the local api. otherwise, this button simply reroutes to the reports page */}
             <div className={classes.tableButtons}>


### PR DESCRIPTION
# Material UI overhaul of selects & form
## Description

Suggestion select are now inline with the TH on both the live report and saved reports.
Saved Reports page styled with MUI
Live Form styled with MUI, using "name" for handling change

Closes #92 
Closes #88 

### Type
- [ ] Bug squish
- [x] New Feature
- [ ] Documentation